### PR TITLE
GCC compilation fixes

### DIFF
--- a/include/ir_value_constant.h
+++ b/include/ir_value_constant.h
@@ -47,8 +47,7 @@ namespace piranha {
         template <typename _T>
         const _T validateData(const _T &data, bool recordErrors = false) { return data; }
 
-        template <>
-        const piranha::native_string validateData<piranha::native_string>(const piranha::native_string &data, bool recordErrors) {
+        const piranha::native_string validateData(const piranha::native_string &data, bool recordErrors) {
             piranha::native_string res;
             piranha::native_string::const_iterator it = data.begin();
             while (it != data.end()) {

--- a/include/language_rules.h
+++ b/include/language_rules.h
@@ -126,10 +126,6 @@ namespace piranha {
 
         template <typename NativeType>
         std::string getLiteralBuiltinName() const { return ""; }
-        template<> std::string getLiteralBuiltinName<piranha::native_bool>() const { return *m_literalRules.lookup(LiteralType::Boolean); }
-        template<> std::string getLiteralBuiltinName<piranha::native_string>() const  { return *m_literalRules.lookup(LiteralType::String); }
-        template<> std::string getLiteralBuiltinName<piranha::native_int>() const  { return *m_literalRules.lookup(LiteralType::Integer); }
-        template<> std::string getLiteralBuiltinName<piranha::native_float>() const { return *m_literalRules.lookup(LiteralType::Float); }
 
         bool checkConversion(const ChannelType *input, const ChannelType *output) const;
         Node *generateConversion(const ChannelType *input, const ChannelType *output);
@@ -180,6 +176,11 @@ namespace piranha {
         NodeAllocator m_defaultNodeAllocator;
         NodeAllocator *m_nodeAllocator;
     };
+
+    template<> inline std::string LanguageRules::getLiteralBuiltinName<piranha::native_bool>() const { return *m_literalRules.lookup(LiteralType::Boolean); }
+    template<> inline std::string LanguageRules::getLiteralBuiltinName<piranha::native_string>() const { return *m_literalRules.lookup(LiteralType::String); }
+    template<> inline std::string LanguageRules::getLiteralBuiltinName<piranha::native_int>() const { return *m_literalRules.lookup(LiteralType::Integer); }
+    template<> inline std::string LanguageRules::getLiteralBuiltinName<piranha::native_float>() const { return *m_literalRules.lookup(LiteralType::Float); }
 
 } /* namespace piranha */
 

--- a/include/memory_management.h
+++ b/include/memory_management.h
@@ -5,13 +5,13 @@
 
 namespace piranha {
 
-    typedef unsigned __int64 mem_size;
+    using mem_size = size_t;
 
     constexpr mem_size KB = 1000;
     constexpr mem_size MB = 1000 * KB;
     constexpr mem_size GB = 1000 * MB;
 
-#define CHECK_ALIGNMENT(pointer, required) assert((((unsigned __int64)((char *)(pointer))) % (required)) == 0)
+#define CHECK_ALIGNMENT(pointer, required) assert((((mem_size)((char *)(pointer))) % (required)) == 0)
 
 } /* namespace piranha */
 


### PR DESCRIPTION
This follows on from #62 to get the code compiling without errors when using GCC. The other PR did most of the work so these are only very minor changes.