### PR TITLE
Use C++17's filesystem header if we can

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,10 +48,17 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(dependencies/libraries/flex/include)
 include_directories(include)
 
-set(Boost_USE_STATIC_LIBS ON)
-set(Boost_USE_MULTITHREADED ON)
-set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.40 COMPONENTS filesystem REQUIRED)
+# Aim for C++17's filesystem first, fallback on boost
+include(CheckCXXSymbolExists)
+check_cxx_symbol_exists(std::filesystem::path::preferred_separator "filesystem" USE_CXX17_FILESYSTEM)
+add_compile_definitions(USE_CXX17_FILESYSTEM=${USE_CXX17_FILESYSTEM})
+
+if (NOT USE_CXX17_FILESYSTEM)
+    set(Boost_USE_STATIC_LIBS ON)
+    set(Boost_USE_MULTITHREADED ON)
+    set(Boost_USE_STATIC_RUNTIME OFF)
+    find_package(Boost 1.40 COMPONENTS filesystem REQUIRED)
+endif()
 
 add_library(piranha STATIC
     # Source files
@@ -166,7 +173,9 @@ add_library(piranha STATIC
     ${FLEX_lexer_OUTPUTS}
 )
 
-target_link_libraries(piranha Boost::filesystem)
+if (NOT USE_CXX17_FILESYSTEM)
+    target_link_libraries(piranha Boost::filesystem)
+endif()
 
 add_executable(piranha_reference_compiler
     # Source files

--- a/include/path.h
+++ b/include/path.h
@@ -3,17 +3,27 @@
 
 #include <string>
 
+#if USE_CXX17_FILESYSTEM
+#include <filesystem>
+#else // USE_CXX17_FILESYSTEM
 // Forward Boost declaration
 namespace boost {
     namespace filesystem {
         class path;
     } /* namespace filesystem */
 } /* namespace boost */
+#endif // USE_CXX17_FILESYSTEM
 
 namespace piranha {
 
-    class Path {        
-    protected: Path(const boost::filesystem::path &path);
+#if USE_CXX17_FILESYSTEM
+    namespace filesystem = std::filesystem;
+#else // USE_CXX17_FILESYSTEM
+    namespace filesystem = boost::filesystem;
+#endif // USE_CXX17_FILESYSTEM
+
+    class Path {
+    protected: Path(const filesystem::path &path);
     public:
         Path(const std::string &path);
         Path(const char *path);
@@ -38,10 +48,10 @@ namespace piranha {
         bool exists() const;
 
     protected:
-        boost::filesystem::path *m_path;
+        filesystem::path *m_path;
 
     protected:
-        const boost::filesystem::path &getBoostPath() const { return *m_path; }
+        const filesystem::path &getBoostPath() const { return *m_path; }
     };
 
 } /* namespace piranha */

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -2,7 +2,9 @@
 
 #include "../include/memory_tracker.h"
 
+#if !USE_CXX17_FILESYSTEM
 #include <boost/filesystem.hpp>
+#endif // USE_CXX17_FILESYSTEM
 
 piranha::Path::Path(const std::string &path) {
     m_path = nullptr;
@@ -15,7 +17,7 @@ piranha::Path::Path(const char *path) {
 }
 
 piranha::Path::Path(const Path &path) {
-    m_path = TRACK(new boost::filesystem::path);
+    m_path = TRACK(new filesystem::path);
     *m_path = path.getBoostPath();
 }
 
@@ -23,8 +25,8 @@ piranha::Path::Path() {
     m_path = nullptr;
 }
 
-piranha::Path::Path(const boost::filesystem::path &path) {
-    m_path = TRACK(new boost::filesystem::path);
+piranha::Path::Path(const filesystem::path &path) {
+    m_path = TRACK(new filesystem::path);
     *m_path = path;
 }
 
@@ -39,11 +41,11 @@ std::string piranha::Path::toString() const {
 void piranha::Path::setPath(const std::string &path) {
     if (m_path != nullptr) delete FTRACK(m_path);
 
-    m_path = TRACK(new boost::filesystem::path(path));
+    m_path = TRACK(new filesystem::path(path));
 }
 
 bool piranha::Path::operator==(const Path &path) const {
-    return boost::filesystem::equivalent(this->getBoostPath(), path.getBoostPath());
+    return filesystem::equivalent(this->getBoostPath(), path.getBoostPath());
 }
 
 piranha::Path piranha::Path::append(const Path &path) const {
@@ -51,14 +53,14 @@ piranha::Path piranha::Path::append(const Path &path) const {
 }
 
 void piranha::Path::getParentPath(Path *path) const {
-    path->m_path = TRACK(new boost::filesystem::path);
+    path->m_path = TRACK(new filesystem::path);
     *path->m_path = m_path->parent_path();
 }
 
 const piranha::Path &piranha::Path::operator=(const Path &b) {
     if (m_path != nullptr) delete FTRACK(m_path);
 
-    m_path = TRACK(new boost::filesystem::path);
+    m_path = TRACK(new filesystem::path);
     *m_path = b.getBoostPath();
 
     return *this;
@@ -73,9 +75,13 @@ std::string piranha::Path::getStem() const {
 }
 
 bool piranha::Path::isAbsolute() const {
+#if USE_CXX17_FILESYSTEM
+    return m_path->is_absolute();
+#else // USE_CXX17_FILESYSTEM
     return m_path->is_complete();
+#endif // USE_CXX17_FILESYSTEM
 }
 
 bool piranha::Path::exists() const {
-    return boost::filesystem::exists(*m_path);
+    return filesystem::exists(*m_path);
 }


### PR DESCRIPTION
This avoids having to find and build boost which is always a nice thing to skip.