### PR TITLE
Fix compilation warnings and C++ correctness issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,13 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(dependencies/libraries/flex/include)
 include_directories(include)
 
+# Suppress warnings in Bison-generated code
+set_source_files_properties(
+    ${CMAKE_CURRENT_BINARY_DIR}/parser.auto.cpp
+    PROPERTIES
+    COMPILE_FLAGS "-Wno-unused-but-set-variable"
+)
+
 add_library(piranha STATIC
     # Source files
     src/assembly.cpp

--- a/include/ir_context_tree.h
+++ b/include/ir_context_tree.h
@@ -15,7 +15,7 @@ namespace piranha {
     public:
         IrContextTree();
         IrContextTree(IrNode *context, bool mainContext = false);
-        ~IrContextTree();
+        virtual ~IrContextTree();
 
         void setParent(IrContextTree *parent) { m_parent = parent; }
         IrContextTree *getParent() const { return m_parent; }

--- a/include/ir_token_info.h
+++ b/include/ir_token_info.h
@@ -76,7 +76,7 @@ namespace piranha {
         }
 
         T_IrTokenInfo(const T &data, int lineStart, int lineEnd, int colStart, int colEnd)
-            : data(data), IrTokenInfo(lineStart, lineEnd, colStart, colEnd) {
+            : IrTokenInfo(lineStart, lineEnd, colStart, colEnd), data(data) {
             /* void */
         }
 

--- a/src/ir_binary_operator.cpp
+++ b/src/ir_binary_operator.cpp
@@ -105,8 +105,8 @@ piranha::IrParserStructure *piranha::IrBinaryOperator::
         if (!publicAttribute->allowsExternalAccess()) {
             IR_FAIL();
 
-            const bool isValidError = (IR_EMPTY_CONTEXT() || touchedMainContext) && 
-                (basicInfo.isFixedType() && IR_EMPTY_CONTEXT() || !basicInfo.isFixedType());
+            const bool isValidError = (IR_EMPTY_CONTEXT() || touchedMainContext) &&
+                ((basicInfo.isFixedType() && IR_EMPTY_CONTEXT()) || !basicInfo.isFixedType());
             if (query.recordErrors && isValidError) {
                 IR_ERR_OUT(TRACK(new CompilationError(*m_rightOperand->getSummaryToken(),
                     ErrorCode::AccessingInternalMember, query.inputContext)));
@@ -189,7 +189,7 @@ void piranha::IrBinaryOperator::_expand(IrContextTree *context) {
                 ((leftInfo.touchedMainContext && !leftInfo.isStaticType()) ||
                 (rightInfo.touchedMainContext && !rightInfo.isStaticType()));
 
-            const bool isOutside = leftInfo.isFixedTypeOutside(context);
+            [[maybe_unused]] const bool isOutside = leftInfo.isFixedTypeOutside(context);
 
             if (touchedMainContext || emptyContext) {
                 getParentUnit()->addCompilationError(

--- a/src/ir_node.cpp
+++ b/src/ir_node.cpp
@@ -417,7 +417,7 @@ piranha::Node *piranha::IrNode::_generateNode(IrContextTree *context, NodeProgra
 
     IrNodeDefinition *definition = getDefinition();
     const IrAttributeDefinitionList *allAttributes = definition->getAttributeDefinitionList();
-    const IrAttributeList *specifiedAttributes = getAttributes();
+    [[maybe_unused]] const IrAttributeList *specifiedAttributes = getAttributes();
 
     NodeContainer *newContainer = parentContainer;
     NodeContainer *generatedContainer = nullptr;

--- a/src/ir_parser_structure.cpp
+++ b/src/ir_parser_structure.cpp
@@ -149,7 +149,7 @@ piranha::IrParserStructure *piranha::IrParserStructure::getReference(
         const IrReferenceChain::Link &link = chain.list[info.infiniteLoop];
 
         if (!link.structure->isInfiniteLoop(link.context)) {
-            if (output != nullptr && output->touchedMainContext || IR_EMPTY_CONTEXT()) {
+            if ((output != nullptr && output->touchedMainContext) || IR_EMPTY_CONTEXT()) {
                 IR_ERR_OUT(TRACK(new CompilationError(*link.structure->getSummaryToken(),
                     ErrorCode::CircularReference, link.context)));
             }
@@ -345,7 +345,7 @@ void piranha::IrParserStructure::checkReferences(IrContextTree *inputContext) {
         query.recordErrors = true;
         IrReferenceInfo info;
 
-        IrParserStructure *reference = getReference(query, &info);
+        [[maybe_unused]] IrParserStructure *reference = getReference(query, &info);
 
         if (info.err != nullptr) {
             getParentUnit()->addCompilationError(info.err);
@@ -438,7 +438,7 @@ void piranha::IrParserStructure::writeReferencesToFile(
     query.inputContext = context;
     query.recordErrors = false;
 
-    IrNode *asNode = getAsNode();
+    [[maybe_unused]] IrNode *asNode = getAsNode();
     IrParserStructure *immediateReference = getImmediateReference(query, &info);
 
     if (info.failed) {

--- a/src/node_program.cpp
+++ b/src/node_program.cpp
@@ -39,7 +39,7 @@ void piranha::NodeProgram::writeAssembly(const std::string &fname) const {
 
 void piranha::NodeProgram::addNode(Node *node) {
     if (CheckDuplicates) {
-        for (Node *n : m_nodeCache) {
+        for ([[maybe_unused]] Node *n : m_nodeCache) {
             assert(n != node);
         }
     }


### PR DESCRIPTION
## Why This PR?

I wanted to build Piranha on macOS (Apple Silicon) and Linux. The original codebase targets Windows/MSVC, and Clang/GCC with `-Wall -Wextra` produces several warnings that indicate real issues.

**Note:** I see PRs #63 and #64 also address cross-platform compilation. My approach focuses on minimal warning fixes in this PR:
- This PR: Bug fixes only (virtual destructor, parentheses, unused variables)
- Platform support (CMake, Boost paths) will be a separate PR if this is accepted

Happy to coordinate or adjust based on maintainer preference.

## Changes

| Fix | Problem | Solution |
|-----|---------|----------|
| Virtual destructor | UB risk when deleting through base pointer | Add \`virtual\` to IrContextTree destructor |
| Logical parens | Ambiguous \`A && B || C\` precedence | Add parentheses for clarity |
| Initializer order | \`-Wreorder\` warning | Reorder to match declarations |
| Unused variables | \`-Wunused-variable\` warning | Add \`[[maybe_unused]]\` attribute |
| Bison warnings | Can't fix generated code | Suppress for that file only |

## Testing

- Built on macOS M4 Pro (Clang 17)
- Built on Linux (GCC)  
- Tested with engine-sim project (uses Piranha)
- No functional changes - all existing behavior preserved

## Files Changed

- \`include/ir_context_tree.h\` - virtual destructor
- \`include/ir_token_info.h\` - initializer order
- \`src/ir_binary_operator.cpp\` - parentheses, maybe_unused
- \`src/ir_node.cpp\` - maybe_unused
- \`src/ir_parser_structure.cpp\` - parentheses, maybe_unused
- \`src/node_program.cpp\` - maybe_unused
- \`CMakeLists.txt\` - suppress Bison warnings