### PR TITLE
Add META_MUTATION flag for mutation node evaluation ordering

### DIFF
--- a/include/node.h
+++ b/include/node.h
@@ -78,6 +78,7 @@ namespace piranha {
         // Standard metadata flags
         static constexpr const char *META_CONSTANT = "!!PIRANHA::CONSTANT";
         static constexpr const char *META_ACTIONLESS = "!!PIRANHA::ACTIONLESS";
+        static constexpr const char *META_MUTATION = "!!PIRANHA::MUTATION";
 
     public:
         Node();

--- a/src/node_program.cpp
+++ b/src/node_program.cpp
@@ -143,9 +143,13 @@ bool piranha::NodeProgram::execute() {
         }
     }
 
-    // Second pass: evaluate all remaining nodes
+    // Second pass: evaluate all remaining nodes (skip mutation nodes already evaluated)
     for (int i = 0; i < nodeCount; i++) {
         Node *node = m_topLevelContainer.getNode(i);
+
+        // Skip mutation nodes as they were already evaluated in the first pass
+        if (node->hasFlag(Node::META_MUTATION)) continue;
+
         const bool result = node->evaluate();
         if (!result) return false;
         if (isKilled()) return true;

--- a/src/node_program.cpp
+++ b/src/node_program.cpp
@@ -130,8 +130,20 @@ bool piranha::NodeProgram::execute() {
     initialize();
 
     if (isKilled()) return true;
-    
-    // Execute all nodes
+
+    // First pass: evaluate all mutation nodes (nodes that modify other nodes)
+    // These must be evaluated before other nodes that depend on the modifications
+    for (int i = 0; i < nodeCount; i++) {
+        Node *node = m_topLevelContainer.getNode(i);
+
+        if (node->hasFlag(Node::META_MUTATION)) {
+            const bool result = node->evaluate();
+            if (!result) return false;
+            if (isKilled()) return true;
+        }
+    }
+
+    // Second pass: evaluate all remaining nodes
     for (int i = 0; i < nodeCount; i++) {
         Node *node = m_topLevelContainer.getNode(i);
         const bool result = node->evaluate();


### PR DESCRIPTION
## Why This PR?

This PR addresses an issue where nodes that modify other nodes via side-effects may evaluate in undefined order relative to their consumers.

### The Problem

In projects using Piranha (like engine-sim), some nodes modify other nodes:
- `AddSampleNode` adds samples to a `FunctionNode.m_samples` vector
- `FunctionNode.generate()` uses those samples

Piranha's default evaluation order is based on the dependency graph, but mutation nodes and their targets are often at the same dependency level. This leads to undefined evaluation order.

**Original behavior**: Worked by accident on some platforms due to container ordering.

**Problem exposed**: Different compiler/linker ordering on other platforms caused the mutation nodes to evaluate after consumers, resulting in empty data.

## Changes

### 1. Add META_MUTATION flag
```cpp
static constexpr const char *META_MUTATION = "!!PIRANHA::MUTATION";
```

### 2. Two-pass evaluation in NodeProgram::execute()
- Phase 1: Evaluate all mutation nodes first
- Phase 2: Evaluate remaining nodes

## Usage

Nodes that modify other nodes via side-effects add the flag:

```cpp
class AddSampleNode : public Node {
public:
    AddSampleNode() {
        addFlag(Node::META_MUTATION);
    }
};
```

## Backward Compatibility

- **Fully backward compatible**
- Only affects nodes with \`META_MUTATION\` flag
- Existing nodes behave identically
- Opt-in feature

## Testing

- Tested with engine-sim project
- Mutation nodes now evaluate before consumers
- No regression in existing behavior

## Alternative Considered

Restructuring downstream projects to use explicit dependencies instead of side-effects would require significant refactoring and break existing scripts. This feature provides a minimal, opt-in solution.